### PR TITLE
Restrict instrall-new to slackware64 and patches

### DIFF
--- a/README.TXT
+++ b/README.TXT
@@ -6,3 +6,16 @@ Slackpkg+ is a plugin for slackpkg.
    It adds support for third-party repositories.
    You can install, upgrade and search from multiple repositories.
 
+### NOTICE ###
+Alienbob has volunteered to take over the mainteneance of slackpkg+ developed
+by Matteo Rossini (zerouno). Alien Bob' blog for more information:
+https://alien.slackbook.org/blog/taking-over-maintenance-of-slackpkgplus/
+
+Alien Bob's fork:
+https://github.com/alienbob/slackpkgplus
+
+I will be maintaining the developnebt (devel) branch. My main focus will be to 
+mirror changes in the master branch of alienbob's fork to the devel branch in my 
+fork and a few minor changes specific to the devel branch. 
+
+See Pinned Announcement in Discussions for more regarding this fork.

--- a/src/slackpkgplus.sh
+++ b/src/slackpkgplus.sh
@@ -1310,17 +1310,16 @@ if [ "$SLACKPKGPLUS" = "on" ];then
             NAME=""
             FULLNAME=""
           fi
-          # When "install-new" is used, there can be same named packages included
-          # in the list from other repositories, only slackware64 and patches should
-          # be used for "install-new" This happens if packages are Addded, then
-          # later Deleted in ChangeLog.txt.
-          if [[ $CMD == install-new ]]; then
-            if [[ ${PKGDATA[0]#*:} != slackware64 ]] && [[ ${PKGDATA[0]#*:} != patches ]]; then
+        fi
+        # When "install-new" is used, there can be same named packages included
+        # in the list from other repositories, only slackware64 and patches should
+        # be used for "install-new" This happens if packages are Addded, then
+        # later Deleted in ChangeLog.txt.
+        if [[ $CMD == install-new ]]; then
+          if [[ ${PKGDATA[0]#*:} != slackware64 ]] && [[ ${PKGDATA[0]#*:} != patches ]]; then
             NAME=""
             FULLNAME=""
           fi
-        fi
-        
         fi
       fi
 

--- a/src/slackpkgplus.sh
+++ b/src/slackpkgplus.sh
@@ -1310,6 +1310,17 @@ if [ "$SLACKPKGPLUS" = "on" ];then
             NAME=""
             FULLNAME=""
           fi
+          # When "install-new" is used, there can be same named packages included
+          # in the list from other repositories, only slackware64 and patches should
+          # be used for "install-new" This happens if packages are Addded, then
+          # later Deleted in ChangeLog.txt.
+          if [[ $CMD == install-new ]]; then
+            if [[ ${PKGDATA[0]#*:} != slackware64 ]] && [[ ${PKGDATA[0]#*:} != patches ]]; then
+            NAME=""
+            FULLNAME=""
+          fi
+        fi
+        
         fi
       fi
 


### PR DESCRIPTION
When "install-new" is used, there can be same named packages included in the list from other repositories, only slackware64 and patches should be used for "install-new" This happens if packages are Addded, then later Deleted in ChangeLog.txt.